### PR TITLE
Improve dice look

### DIFF
--- a/geometry.js
+++ b/geometry.js
@@ -1,16 +1,42 @@
 const size = 1.5; // Size of the dice
 
+function createRoundedBoxGeometry(length, radius = 0.15, smoothness = 2) {
+    const shape = new THREE.Shape();
+    const eps = 0.00001;
+    const radius0 = radius - eps;
+    const l = length - radius * 2;
+
+    shape.absarc(eps, eps, eps, -Math.PI / 2, -Math.PI, true);
+    shape.absarc(eps, l + eps, eps, Math.PI, Math.PI / 2, true);
+    shape.absarc(l + eps, l + eps, eps, Math.PI / 2, 0, true);
+    shape.absarc(l + eps, eps, eps, 0, -Math.PI / 2, true);
+
+    const geometry = new THREE.ExtrudeGeometry(shape, {
+        depth: l,
+        bevelEnabled: true,
+        bevelSegments: smoothness * 2,
+        steps: 1,
+        bevelSize: radius0,
+        bevelThickness: radius,
+        curveSegments: smoothness,
+    });
+
+    geometry.center();
+    return geometry;
+}
+
 export function createDice(scene, x, y, z, faces) {
     const loader = new THREE.TextureLoader();
     const textures = faces.map(face => loader.load(face));
 
-    // Geometry for the dice (cube)
-    const geometry = new THREE.BoxGeometry(size, size, size);
+    // Geometry for the dice with rounded edges
+    const geometry = createRoundedBoxGeometry(size, 0.2, 3);
 
     // Use MeshStandardMaterial for realistic shading
     const materials = textures.map(texture =>
         new THREE.MeshStandardMaterial({
             map: texture,
+            color: 0xffffff,
             roughness: 0.5,
             metalness: 0.2,
         })


### PR DESCRIPTION
## Summary
- introduce `createRoundedBoxGeometry` helper
- use rounded geometry for dice
- ensure dice surfaces are white

## Testing
- `node -e "import('./geometry.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_68593d2246c8832299980e2fc79aa942