### PR TITLE
Responsive dice layout

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -35,12 +35,12 @@ export class Dice {
         rotateDice(this.mesh);
     }
 
-    display(index) {
+    display(x, y = 0, z = 0) {
         let faces = [];
         for (const face of this.faces) {
             faces.push(face.texture());
         }
-        this.mesh = createDice(this.diceSet.scene, -3 + index * 2, 0, 0, faces, this.color);
+        this.mesh = createDice(this.diceSet.scene, x, y, z, faces, this.color);
         return this.mesh;
     }
 }
@@ -64,8 +64,22 @@ export class DiceSet {
     }
 
     display() {
+        // Remove previously displayed dice
+        for (const mesh of this.diceMeshes) {
+            this.scene.remove(mesh);
+        }
+        this.diceMeshes = [];
+
+        const dicePerRow = window.innerWidth < 768 ? 3 : 5;
+        const rows = Math.ceil(this.dice.length / dicePerRow);
+        const spacing = 2;
+
         for (let i = 0; i < this.dice.length; i++) {
-            let diceMesh = this.dice[i].display(i);
+            const row = Math.floor(i / dicePerRow);
+            const col = i % dicePerRow;
+            const x = (col - (dicePerRow - 1) / 2) * spacing;
+            const z = (row - (rows - 1) / 2) * -spacing;
+            let diceMesh = this.dice[i].display(x, 0, z);
             this.diceMeshes.push(diceMesh);
         }
     }

--- a/geometry.js
+++ b/geometry.js
@@ -1,4 +1,7 @@
-const size = 1.5; // Size of the dice
+// Dice size is a bit larger on desktop screens
+function getDiceSize() {
+    return window.innerWidth < 768 ? 1.5 : 2;
+}
 
 export function createDice(scene, x, y, z, faces, diceColor = 0xffffff) {
     const loader = new THREE.TextureLoader();
@@ -26,6 +29,7 @@ export function createDice(scene, x, y, z, faces, diceColor = 0xffffff) {
     }
     
     // Use BoxGeometry with more segments for subtle rounded edges
+    const size = getDiceSize();
     const geometry = new THREE.BoxGeometry(size, size, size, 3, 3, 3);
 
     const dice = new THREE.Mesh(geometry, materials);

--- a/index.js
+++ b/index.js
@@ -181,6 +181,9 @@ window.addEventListener('resize', () => {
     renderer.setSize(window.innerWidth, window.innerHeight);
     camera.aspect = window.innerWidth / window.innerHeight;
     camera.updateProjectionMatrix();
+    if (diceSet) {
+        diceSet.display();
+    }
 });
 
 // // Add another dice when the button is clicked


### PR DESCRIPTION
## Summary
- compute dice size based on screen width
- position dice in a responsive grid
- recreate dice grid on resize

## Testing
- `node --check geometry.js`
- `node --check dice.js`
- `node --check index.js`


------
https://chatgpt.com/codex/tasks/task_e_685950ea79dc8322bcedb794c3436ffd