### PR TITLE
Fix dice face backgrounds

### DIFF
--- a/geometry.js
+++ b/geometry.js
@@ -86,7 +86,7 @@ export function createDice(scene, x, y, z, faces, diceColor = 0xffffff) {
         ) {
             const texture = loader.load(face);
             material = new THREE.MeshStandardMaterial({
-                color: 0xC1C1C1,
+                color: 0xffffff,
                 map: texture,
                 transparent: true,
             });


### PR DESCRIPTION
## Summary
- whiten background behind dice face textures so images are placed on a white surface

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a72118b148322869acb16d2e152ca